### PR TITLE
Support spaces in file names during publish

### DIFF
--- a/lib/publish.js
+++ b/lib/publish.js
@@ -38,17 +38,17 @@ function compileDocument ({ source, recipe, format }) {
   let pandocCmd = 'pandoc ';
 
   // source file
-  pandocCmd += source;
+  pandocCmd += `"${source}"`;
 
   // target file
   const target = path.join(
     targetDir,
     `${path.basename(source, '.md')}.${instructions.format}`
   );
-  pandocCmd += ` -o ${target}`;
+  pandocCmd += ` -o "${target}"`;
 
   // include source directory in search path (allow relative path to images)
-  pandocCmd += ` --resource-path=${path.dirname(source)}`;
+  pandocCmd += ` --resource-path="${path.dirname(source)}"`;
 
   // check for bibliography: front-matter > default bib > none
   const bibliography =
@@ -56,16 +56,16 @@ function compileDocument ({ source, recipe, format }) {
   const bibliographyPath = path.resolve(path.dirname(source), bibliography);
 
   if (fs.existsSync(bibliographyPath)) {
-    pandocCmd += ` --bibliography=${bibliographyPath}`;
+    pandocCmd += ` --bibliography="${bibliographyPath}"`;
   }
 
   // use template if needed
   if (instructions.template) {
-    pandocCmd += ` --template=${path.join(
+    pandocCmd += ` --template="${path.join(
       recipesFolder,
       instructions.name,
       instructions.template
-    )}`;
+    )}"`;
   }
 
   // add pandoc options


### PR DESCRIPTION
If there are spaces in file names then the publish command fails. On Windows at least, enclosing the paths in quotation marks prevents this error.