### PR TITLE
Allow "tex" as a format from the CLI

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -31,7 +31,7 @@ prog
   .command('publish', 'Compile a manuscript using pandoc')
   .argument('[source]', 'Source file', /\.md$/, 'manuscript.md')
   .option('--to <recipe>', 'template to use for compiling')
-  .option('-f, --format <ext>', 'Destination format extension', /^pdf|docx|html|tex$/)
+  .option('-f, --format <ext>', 'Destination format extension')
   .action(publish);
 
 manage();

--- a/cli.js
+++ b/cli.js
@@ -31,7 +31,7 @@ prog
   .command('publish', 'Compile a manuscript using pandoc')
   .argument('[source]', 'Source file', /\.md$/, 'manuscript.md')
   .option('--to <recipe>', 'template to use for compiling')
-  .option('-f, --format <ext>', 'Destination format extension', /^pdf|docx|html$/)
+  .option('-f, --format <ext>', 'Destination format extension', /^pdf|docx|html|tex$/)
   .action(publish);
 
 manage();

--- a/lib/load-instructions.js
+++ b/lib/load-instructions.js
@@ -73,6 +73,9 @@ function loadInstructions ({ recipe, format }) {
       // no recipe file, but the format can help guess the template
       // '''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''
     }
+    // check if the given format has defaults we can use
+    if (!formatMap[format]) throw new Error(`No defaults exist for unknown format - ${format}`);
+    
     // see if we can find a file that look like a template for the given format
     const candidates = fsTools
       .listFiles(recipePath, { type: 'file' })

--- a/lib/load-instructions.js
+++ b/lib/load-instructions.js
@@ -4,6 +4,7 @@ const path = require('path');
 const config = require('../config.js');
 
 const formatMap = {
+  tex: ['.tex', '.latex', '.xelatex'],
   pdf: ['.tex', '.latex', '.xelatex'],
   docx: ['.doc', '.docx'],
   html: ['.html']


### PR DESCRIPTION
Sometimes I just want to generate a LaTeX file using pandemic, without compiling to PDF. 
I can do this for my own recipe by setting `format: tex` in the receipe and it looks for either
`receipe.tex.json` or `mytemplate.tex`, however the CLI throws an error when I try 
`pandemic publish -f tex`