### PR TITLE
Support bibliography arrays

### DIFF
--- a/lib/publish.js
+++ b/lib/publish.js
@@ -75,12 +75,16 @@ function compileDocument ({
     pandocCmd += ` --resource-path="${path.dirname(source)}"`;
 
     // check for bibliography: front-matter > default bib > none
-    const bibliography = yamlOptions.bibliography || 'bibliography.bib';
-    const bibliographyPath = path.resolve(path.dirname(source), bibliography);
+    let bibliography = yamlOptions.bibliography || ['bibliography.bib'];
+    if (typeof bibliography === 'string') bibliography = [bibliography];
 
-    if (fs.existsSync(bibliographyPath)) {
-      pandocCmd += ` --bibliography="${bibliographyPath}"`;
-    }
+    bibliography.forEach(bib => {
+      const bibliographyPath = path.resolve(path.dirname(source), bib);
+
+      if (fs.existsSync(bibliographyPath)) {
+        pandocCmd += ` --bibliography="${bibliographyPath}"`;
+      }
+    })
 
     // use template
     if (instructions.template) {


### PR DESCRIPTION
Pandoc supports arrays of bibtex files:

> --bibliography=FILE
>    Set the bibliography field in the document’s metadata to FILE, overriding any value set in the metadata, and process citations using pandoc-citeproc. (This is equivalent to --metadata bibliography=FILE --filter pandoc-citeproc.) If --natbib or --biblatex is also supplied, pandoc-citeproc is not used, making this equivalent to --metadata bibliography=FILE. **If you supply this argument multiple times, each FILE will be added to bibliography.**

In addition, [some editor extensions](https://github.com/notZaki/PandocCiter) only work when the YAML front matter contains an array of bibliography files. This adds support for an array of bibliography files to pandemic, while still supporting plain strings in the frontmatter.